### PR TITLE
Use "type": "wp-cli-package" to designate this as a WP-CLI package

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -1,6 +1,7 @@
 {
   "name": "trendwerk/faker",
   "description": "Fake post data with WP-CLI.",
+  "type": "wp-cli-package",
   "homepage": "https://github.com/trendwerk/faker",
   "license": "GPL-3.0+",
   "authors": [


### PR DESCRIPTION
See https://github.com/wp-cli/wp-cli/issues/2567
