### PR TITLE
Exclude non-essential files

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,11 @@
+* text=auto eol=lf
+
+/bin export-ignore
+/features export-ignore
+/utils export-ignore
+/.gitattributes export-ignore
+/.gitignore export-ignore
+/.travis.yml export-ignore
+/gulpfile.js export-ignore
+/package.json export-ignore
+/README.md export-ignore


### PR DESCRIPTION
This way the users of this package doesn't have to download non-essential files which aren't necessary for the package to function. Such as files used for development (docs, screenshots, tests, .travis.yml, etc). 

Composer will remove any files specified in the `.gitattributes` file if we run either the install or update commands with the `--prefer-dist` flag.

This is related to #18