### PR TITLE
Add fzaninotto/faker as dependency

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -22,6 +22,7 @@
     "squizlabs/php_codesniffer": "2.*"
   },
   "require": {
+    "fzaninotto/faker": "^1.8",
     "nelmio/alice": "^2.2"
   }
 }


### PR DESCRIPTION
Since this package are using a `fzaninotto/faker` dependency in `Trendwerk\Faker\Provider\Term` we should require the package as an dependency.

https://github.com/trendwerk/faker/blob/ec5643a9f7f8aaf2b0b7e172efaa36dfd8706bc8/src/Provider/Term.php#L1-L17