### PR TITLE
Add short description

### DIFF
--- a/init.php
+++ b/init.php
@@ -7,4 +7,6 @@ if (! class_exists('WP_CLI')) {
     return;
 }
 
-WP_CLI::add_command('faker', __NAMESPACE__ . '\\Command');
+WP_CLI::add_command('faker', __NAMESPACE__ . '\\Command', [
+    'shortdesc' => 'Fake post data with WP-CLI.',
+]);


### PR DESCRIPTION
This will display the following text when running `wp help faker`:

```
NAME

  wp faker

DESCRIPTION

  Fake post data with WP-CLI.
...
```