### PR TITLE
Added wp-cli/wp-cli as dependency

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ Relies on [nelmio/alice](https://github.com/nelmio/alice) and [fzaninotto/Faker]
 wp package install trendwerk/faker
 ```
 
-Requires [wp-cli](https://github.com/wp-cli/wp-cli) >= 0.23.
+Requires [wp-cli](https://github.com/wp-cli/wp-cli) >= 2.0.
 
 ## Usage
 ```sh

--- a/composer.json
+++ b/composer.json
@@ -23,6 +23,7 @@
   },
   "require": {
     "fzaninotto/faker": "^1.8",
-    "nelmio/alice": "^2.2"
+    "nelmio/alice": "^2.2",
+    "wp-cli/wp-cli": "^2.0"
   }
 }


### PR DESCRIPTION
Similar to #21 we should install `wp-cli/wp-cli` as an dependency since we're using the `WP_CLi` class in the `Command.php` file:

https://github.com/trendwerk/faker/blob/1c023b36dbabc71783e8c90174686ffcc71a5f6d/src/Command.php#L4

Just a heads up: this pull request updates to version 2.0. I don't see any issues since version 2.0 is a much more polished version of the `wp-cli` tool.